### PR TITLE
Fixed initial load of project page

### DIFF
--- a/javascripts/developer-materials.angular.js
+++ b/javascripts/developer-materials.angular.js
@@ -551,6 +551,9 @@ dcp.controller('developerMaterialsController',
     );
 
     $scope.params.size  = $scope.pagination.size;
+    
+    // fold in initial project 
+    $scope.params.project = $scope.filters.project;
 
     // Go get new materials and display them
     materialService.getMaterials($scope.params)


### PR DESCRIPTION
Somewhere in the DCP2 migration lukas started using params instead of filters and trying to sync them is a bit confusing now. I've tracked it down to the params not having the project from the filter on page load. 
