### PR TITLE
[DEVELOPER-3465] Start supporting services, tests and HTTPD config fix

### DIFF
--- a/_docker/environments/drupal-dev-local-dcp/apache/httpd.conf
+++ b/_docker/environments/drupal-dev-local-dcp/apache/httpd.conf
@@ -115,10 +115,10 @@ LoadModule headers_module modules/mod_headers.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule version_module modules/mod_version.so
 #LoadModule remoteip_module modules/mod_remoteip.so
-#LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_module modules/mod_proxy.so
 #LoadModule proxy_connect_module modules/mod_proxy_connect.so
 #LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
-#LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
 #LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
 #LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
 #LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so

--- a/_docker/environments/drupal-dev/apache/httpd.conf
+++ b/_docker/environments/drupal-dev/apache/httpd.conf
@@ -115,10 +115,10 @@ LoadModule headers_module modules/mod_headers.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule version_module modules/mod_version.so
 #LoadModule remoteip_module modules/mod_remoteip.so
-#LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_module modules/mod_proxy.so
 #LoadModule proxy_connect_module modules/mod_proxy_connect.so
 #LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
-#LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
 #LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
 #LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
 #LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so

--- a/_docker/lib/rhd_environment.rb
+++ b/_docker/lib/rhd_environment.rb
@@ -121,7 +121,7 @@ class RhdEnvironment
     case @environment_name
       when 'awestruct-dev', 'awestruct-pull-request'
          supporting_services += %w(mysql searchisko)
-      when 'drupal-dev'
+      when 'drupal-dev', 'drupal-dev-local-dcp'
         supporting_services+= %w(apache mysql searchisko drupalmysql drupal)
       when 'drupal-pull-request'
          supporting_services+= %w(mysql searchisko drupalmysql drupal)

--- a/_docker/tests/test_rhd_environment.rb
+++ b/_docker/tests/test_rhd_environment.rb
@@ -125,6 +125,11 @@ class TestRhdEnvironment < MiniTest::Test
     assert_equal(%w(mysql searchisko), @environment.get_supporting_services)
   end
 
+  def test_supporting_services_drupal_dev_local_dcp
+    @environment.environment_name = 'drupal-dev-local-dcp'
+    assert_equal(%w(apache mysql searchisko drupalmysql drupal), @environment.get_supporting_services)
+  end
+
   def test_supporting_services_drupal_dev
     @environment.environment_name = 'drupal-dev'
     assert_equal(%w(apache mysql searchisko drupalmysql drupal), @environment.get_supporting_services)


### PR DESCRIPTION
This PR:
1.  Ensures that we correctly start the required supporting services in drupal-dev-local-dcp env
2. Provides a test for the above
3. Fixes a regression in the Apache HTTPD config that prevents the export from working (regression was caused elsewhere and not in this branch).
